### PR TITLE
Update symfony/validator required version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/validator": ">=2.1,<=2.3"
+        "symfony/validator": ">=2.1,<2.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hello there !

This pull request update `symfony/validator` dependency version to `>=2.1,<2.4`

This enable use of the bundle in project based on the 2.3.x version of the Symfony framework.

As no BC breaks is introduce in `symfony/validator` 2.3.x, it won't be a problem. Test passed.
